### PR TITLE
Remove warning: unused variable: `path`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,8 +38,8 @@ impl Fairing for CORS {
     }
 }
 
-#[options("/<path..>")]
-fn options(path: PathBuf){}
+#[options("/<_path..>")]
+fn options(_path: PathBuf){}
 
 
 /// Returns a new address for the provided output descriptor


### PR DESCRIPTION
Remove warning: unused variable: `path`